### PR TITLE
Ensure newline in center_shift diff

### DIFF
--- a/tests/test_center_shift_diff.py
+++ b/tests/test_center_shift_diff.py
@@ -27,3 +27,14 @@ def test_process_one(tmp_path):
     assert text.strip() != ''
     assert 'Median' in text
     assert 'code:' in text
+
+
+def test_make_table_newline():
+    csv = Path('tex-src/data/prices/1321.csv')
+    df = diff.calc_center_shift(diff.read_prices(csv), phase=2)
+    tex = diff.make_table(df, code='1321')
+    lines = tex.splitlines()
+    assert lines[0].startswith('\\noindent')
+    assert lines[0].endswith('\\')
+    assert lines[1] == '\\begingroup'
+    assert tex.endswith('\\endgroup\n')

--- a/tex-src/data/analysis/center_shift/1321_diff.tex
+++ b/tex-src/data/analysis/center_shift/1321_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:1321}\\
+\noindent\textbf{code:1321}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/4755_diff.tex
+++ b/tex-src/data/analysis/center_shift/4755_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:4755}\\
+\noindent\textbf{code:4755}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/6723_diff.tex
+++ b/tex-src/data/analysis/center_shift/6723_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:6723}\\
+\noindent\textbf{code:6723}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/7203_diff.tex
+++ b/tex-src/data/analysis/center_shift/7203_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:7203}\\
+\noindent\textbf{code:7203}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8034_diff.tex
+++ b/tex-src/data/analysis/center_shift/8034_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8034}\\
+\noindent\textbf{code:8034}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8604_diff.tex
+++ b/tex-src/data/analysis/center_shift/8604_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8604}\\
+\noindent\textbf{code:8604}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8750_diff.tex
+++ b/tex-src/data/analysis/center_shift/8750_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8750}\\
+\noindent\textbf{code:8750}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8801_diff.tex
+++ b/tex-src/data/analysis/center_shift/8801_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8801}\\
+\noindent\textbf{code:8801}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/9432_diff.tex
+++ b/tex-src/data/analysis/center_shift/9432_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:9432}\\
+\noindent\textbf{code:9432}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/9984_diff.tex
+++ b/tex-src/data/analysis/center_shift/9984_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:9984}\\
+\noindent\textbf{code:9984}\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.14  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.15  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-06  v2.15: コード表記直後の改行処理を明確化
 - 2025-06-06  v2.14: diff テーブル末尾に改行を付与
 - 2025-06-06  v2.13: "code:" 表示を表上部のキャプションへ移動
 - 2025-06-06  v2.12: α_t/λ_shift/Δα_t 列を追加し code 表示を挿入
@@ -234,8 +235,10 @@ def make_table(df: pd.DataFrame, code: str = "") -> str:
     ]
     footnote = "\n".join(footnote_lines)
 
-    parts = [
-        (f"\\noindent\\textbf{{code:{code}}}\\" if code else ""),
+    parts = []
+    if code:
+        parts.append(f"\\noindent\\textbf{{code:{code}}}\\")
+    parts += [
         r"\begingroup",
         r"\footnotesize",
         r"\setlength{\tabcolsep}{3.5pt}%",


### PR DESCRIPTION
## Summary
- fix newline handling in csv_to_center_shift_diff.make_table
- regenerate *_diff.tex outputs
- verify newline placement in new pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842866516e48328bd542ee19f0bdd91