### PR TITLE
Add jinja2 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ cython>=0.29
 
 # 基本パッケージ
 pandas>=1.5,<2
+jinja2
 fastapi
 uvicorn[standard]
 


### PR DESCRIPTION
## Summary
- include `jinja2` alongside the basic packages in `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842b1a86db4832882133cb1958f374f