### PR TITLE
Fix newline in code line

### DIFF
--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.15  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.17  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-06  v2.17: code 行の改行処理を明確化
+- 2025-06-06  v2.16: code 表記後の改行が 1 つのみになる不具合を修正
 - 2025-06-06  v2.15: コード表記直後の改行処理を明確化
 - 2025-06-06  v2.14: diff テーブル末尾に改行を付与
 - 2025-06-06  v2.13: "code:" 表示を表上部のキャプションへ移動
@@ -237,7 +239,7 @@ def make_table(df: pd.DataFrame, code: str = "") -> str:
 
     parts = []
     if code:
-        parts.append(f"\\noindent\\textbf{{code:{code}}}\\")
+        parts.append(r"\noindent\textbf{code:%s}\\" % code)
     parts += [
         r"\begingroup",
         r"\footnotesize",


### PR DESCRIPTION
## Summary
- clarify newline handling for the code line in diff tables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68429be0e19483289153af943621528c