### PR TITLE
Fix newline in code line

### DIFF
--- a/tex-src/data/analysis/center_shift/1321_diff.tex
+++ b/tex-src/data/analysis/center_shift/1321_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:1321}\
+\noindent\textbf{code:1321}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/4755_diff.tex
+++ b/tex-src/data/analysis/center_shift/4755_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:4755}\
+\noindent\textbf{code:4755}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/6723_diff.tex
+++ b/tex-src/data/analysis/center_shift/6723_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:6723}\
+\noindent\textbf{code:6723}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/7203_diff.tex
+++ b/tex-src/data/analysis/center_shift/7203_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:7203}\
+\noindent\textbf{code:7203}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8034_diff.tex
+++ b/tex-src/data/analysis/center_shift/8034_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8034}\
+\noindent\textbf{code:8034}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8604_diff.tex
+++ b/tex-src/data/analysis/center_shift/8604_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8604}\
+\noindent\textbf{code:8604}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8750_diff.tex
+++ b/tex-src/data/analysis/center_shift/8750_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8750}\
+\noindent\textbf{code:8750}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/8801_diff.tex
+++ b/tex-src/data/analysis/center_shift/8801_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:8801}\
+\noindent\textbf{code:8801}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/9432_diff.tex
+++ b/tex-src/data/analysis/center_shift/9432_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:9432}\
+\noindent\textbf{code:9432}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/data/analysis/center_shift/9984_diff.tex
+++ b/tex-src/data/analysis/center_shift/9984_diff.tex
@@ -1,4 +1,4 @@
-\noindent\textbf{code:9984}\
+\noindent\textbf{code:9984}\\
 \begingroup
 \footnotesize
 \setlength{\tabcolsep}{3.5pt}%

--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.15  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.18  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-06  v2.18: code 行末の二重バックスラッシュ漏れを修正
+- 2025-06-06  v2.17: code 行の改行処理を明確化
+- 2025-06-06  v2.16: code 表記後の改行が 1 つのみになる不具合を修正
 - 2025-06-06  v2.15: コード表記直後の改行処理を明確化
 - 2025-06-06  v2.14: diff テーブル末尾に改行を付与
 - 2025-06-06  v2.13: "code:" 表示を表上部のキャプションへ移動
@@ -237,7 +240,7 @@ def make_table(df: pd.DataFrame, code: str = "") -> str:
 
     parts = []
     if code:
-        parts.append(f"\\noindent\\textbf{{code:{code}}}\\")
+        parts.append(rf"\noindent\textbf{{code:{code}}}\\")
     parts += [
         r"\begingroup",
         r"\footnotesize",


### PR DESCRIPTION
## Summary
- fix newline handling for the code line in diff tables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68429be0e19483289153af943621528c