### PR TITLE
Fix center shift scaling and include phase3

### DIFF
--- a/tex-src/center_shift/phase3.tex
+++ b/tex-src/center_shift/phase3.tex
@@ -1,0 +1,57 @@
+%-------------------------------------------------------------------------------
+% center_shift/phase3.tex   v1.0  (2025-06-06)
+%-------------------------------------------------------------------------------
+% CHANGELOG  -- new entry on top (latest -> oldest)
+% - 2025-06-06  v1.0 : 初版
+%-------------------------------------------------------------------------------
+
+%=== center_shift =============================================================
+\section*{center\_shift}\nopagebreak[4]
+
+%=== Phase 3 : \alpha_t の深掘り ==============================================
+\subsection*{Phase 3：\alpha_t の深掘り}\nopagebreak[4]
+%────────────────────────────────────
+\paragraph{ステップ／目的}
+\begin{flushleft}
+\begin{enumerate}
+  \item \textbf{基準値}\;前日中値
+        \(B_{t-1}=\tfrac{High_{t-1}+Low_{t-1}}{2}\)
+  \item \textbf{予想中央値}\;
+        \(C_{p,t}=B_{t-1}\bigl(1+\alpha_t\sigma_t^{\mathrm{shift}}\bigr)\)
+  \item \textbf{誤差正規化}\;
+        \(\mathrm{Norm\_err}_t
+          =|C_{p,t}-C_{r,t}|\big/\bigl(B_{t-1}\sigma_t^{\mathrm{shift}}\bigr)\)
+  \item \textbf{シフト解釈}\;\(\alpha_t\) はボラ単位での中心シフト量を示す
+\end{enumerate}
+\end{flushleft}
+
+\subsubsection*{変数のポイント}
+\begin{flushleft}
+\begin{itemize}
+  \item \(\sigma_t^{\mathrm{shift}}\) は Phase 2 までと同じ EWMA14 系列
+  \item \(\alpha_t\sigma_t^{\mathrm{shift}}\) により、銘柄価格スケールへ依存しない
+  \item 小幅な値では \(C_{p,t}\approx B_{t-1}\) となり保守的な予測に
+\end{itemize}
+\end{flushleft}
+
+\subsubsection*{実装ヒント}
+\begin{flushleft}
+初期 5 日間は \(\alpha_t=0\) としてシフトを無効化し、\par
+30~d のウォームアップ後に各係数の更新を開始すると安定します。
+\end{flushleft}
+
+\subsubsection*{追加変数・係数}
+\begin{flushleft}
+\begin{minipage}{0.88\textwidth}
+\begin{tabularx}{\textwidth}{@{}>{\hfil$\displaystyle}l<{$\hfil}@{\quad}X@{}}\toprule
+記号 & 定義・役割 \\\midrule
+B_{t-1} & 前日中値 (High+Low)/2 \\
+C_{p,t} & 予想中央値 \\
+C_{r,t} & 実際中央値 \\
+\mathrm{Norm\_err}_t & 正規化誤差 \\
+\alpha_t & 中心シフト量 (ボラ単位) \\\bottomrule
+\end{tabularx}
+\end{minipage}
+\end{flushleft}
+\bigskip
+%===============================================================================

--- a/tex-src/parent.tex
+++ b/tex-src/parent.tex
@@ -1,6 +1,7 @@
 % parent.tex   v1.0  (2025-05-29)
 % ───────────────────────────────────────────
 % CHANGELOG:
+% - 2025-06-06  center_shift phase3 追加
 % - 2025-05-29  open_price ディレクトリ分割に合わせて新規作成
 %
 % Header-rules:
@@ -50,6 +51,9 @@
 \clearpage
 
 \include{center_shift/phase2}       % Phase-2：σ 比補正
+\clearpage
+
+\include{center_shift/phase3}       % Phase-3：\alpha_t 深掘り
 \clearpage
 
 \include{range/phase0}             % Phase-0：半レンジ m_t

--- a/tex-src/scripts/csv_to_center_shift_batch.py
+++ b/tex-src/scripts/csv_to_center_shift_batch.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_batch.py   v6.8  (2025-06-05)
+scripts/csv_to_center_shift_batch.py   v6.9  (2025-06-05)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_batch.py  （newest → oldest）
+- 2025-06-06  v6.9 : 新スケーリング式に対応
 - 2025-06-06  v6.8 : summary.tex に Median 行を追加
 - 2025-06-05  v6.7 : HitRate 改善アルゴリズムに対応
 - 2025-06-05  v6.6 : LaTeX ヘッダの上付記号を数式モードへ

--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.20  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.21  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-06  v2.21: C_pred/Norm_err の σ スケーリング修正
 - 2025-06-06  v2.20: code 行キャプションを出力しない
 - 2025-06-06  v2.19: \resizebox 終端のコメントを除去
 - 2025-06-06  v2.18: code 行末の二重バックスラッシュ漏れを修正
@@ -142,12 +143,12 @@ def calc_center_shift(df: pd.DataFrame, phase: int = 2) -> pd.DataFrame:
         "Close": df["Close"]
     })
     out["B_{t-1}"] = (out["High"].shift(1) + out["Low"].shift(1)) / 2
-    out["C_pred"]  = out["B_{t-1}"] * (1 + out[r"$\alpha_t$"])
+    out["C_pred"]  = out["B_{t-1}"] * (1 + out[r"$\alpha_t$"] * out[r"$\sigma_t^{\mathrm{shift}}$"])
     out["C_real"]  = (out["High"] + out["Low"]) / 2
     out["C_diff"]  = out["C_pred"] - out["C_real"]
 
     out["C_diff_sign"] = np.sign(out["C_diff"])
-    out["Norm_err"]    = np.abs(out["C_diff"]) / out[r"$\sigma_t^{\mathrm{shift}}$"]
+    out["Norm_err"]    = np.abs(out["C_diff"]) / (out["B_{t-1}"] * out[r"$\sigma_t^{\mathrm{shift}}$"])
     out["MAE_5d"]      = out["C_diff"].abs().rolling(5, min_periods=1).mean()
     out["RelMAE"]      = out["MAE_5d"] / out["Close"] * 100       # %
     hit = (np.sign(out[r"$\alpha_t$"]) ==


### PR DESCRIPTION
## Summary
- update parent.tex to include phase3 and add changelog entry
- adjust center shift scripts to use volatility-scaled alpha
- bump script versions for batch & diff modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6842c64dcf688328ab8876ce4660b12c