### PR TITLE
Add J-Quants statement downloader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+JQUANTS_EMAIL=your@email.com
+JQUANTS_PASSWORD=yourpassword
+JQUANTS_REFRESH_TOKEN=your-refresh-token

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ plotly
 
 # API & 外部サービス
 requests
+jquants-api-client
 openai
 slack_sdk
 

--- a/tex-src/scripts/fetch_statements.py
+++ b/tex-src/scripts/fetch_statements.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""scripts/fetch_statements.py   v1.0  (2025-06-08)
+────────────────────────────────────────────────────────
+CHANGELOG:
+- 2025-06-08  v1.0 : 初版。prices 内の銘柄の statements を CSV 保存
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+import requests
+
+# ──────────────────────────────────────────────────────────────
+ROOT = Path(__file__).resolve().parent.parent
+PRICES_DIR = ROOT / "data" / "prices"
+EARN_DIR = ROOT / "data" / "earn"
+API_BASE = "https://api.jquants.com/v1"
+
+
+def get_token(mail: str, password: str) -> str:
+    res = requests.post(
+        f"{API_BASE}/token/auth_user",
+        data={"mailaddress": mail, "password": password},
+    )
+    res.raise_for_status()
+    return res.json()["accessToken"]
+
+
+def fetch_statements(token: str, code: str, date: str) -> pd.DataFrame:
+    headers = {"Authorization": f"Bearer {token}"}
+    params = {"code": code, "date": date}
+    res = requests.get(f"{API_BASE}/fins/statements", headers=headers, params=params)
+    res.raise_for_status()
+    data = res.json()
+    if isinstance(data, dict) and "statements" in data:
+        records = data["statements"]
+    else:
+        records = data
+    return pd.DataFrame(records)
+
+
+def list_codes() -> list[str]:
+    return [p.stem for p in PRICES_DIR.glob("*.csv")]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="J-Quants statements downloader")
+    parser.add_argument(
+        "--date",
+        default=datetime.today().strftime("%Y%m%d"),
+        help="取得基準日 (yyyymmdd)",
+    )
+    args = parser.parse_args()
+
+    mail = os.getenv("JQUANTS_EMAIL")
+    pwd = os.getenv("JQUANTS_PASSWORD")
+    if not (mail and pwd):
+        raise SystemExit("JQUANTS_EMAIL/PASSWORD not set")
+
+    token = get_token(mail, pwd)
+
+    EARN_DIR.mkdir(parents=True, exist_ok=True)
+    for code in list_codes():
+        df = fetch_statements(token, code, args.date)
+        out = EARN_DIR / f"{code}.csv"
+        df.to_csv(out, index=False)
+        print(f"✅ saved: {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tex-src/scripts/fetch_statements.py
+++ b/tex-src/scripts/fetch_statements.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""scripts/fetch_statements.py   v1.1  (2025-06-08)
+"""scripts/fetch_statements.py   v1.2  (2025-06-08)
 ────────────────────────────────────────────────────────
 CHANGELOG:
+- 2025-06-08  v1.2 : fix .env path to repository root
 - 2025-06-08  v1.1 : .env から認証情報を読み込み、Refresh Token 対応
 - 2025-06-08  v1.0 : 初版。prices 内の銘柄の statements を CSV 保存
 """
@@ -19,9 +20,10 @@ import requests
 from dotenv import load_dotenv
 
 # ──────────────────────────────────────────────────────────────
-ROOT = Path(__file__).resolve().parent.parent
-PRICES_DIR = ROOT / "data" / "prices"
-EARN_DIR = ROOT / "data" / "earn"
+ROOT = Path(__file__).resolve().parents[2]
+TEX_ROOT = ROOT / "tex-src"
+PRICES_DIR = TEX_ROOT / "data" / "prices"
+EARN_DIR = TEX_ROOT / "data" / "earn"
 API_BASE = "https://api.jquants.com/v1"
 
 load_dotenv(ROOT / ".env")

--- a/tex-src/scripts/fetch_statements.py
+++ b/tex-src/scripts/fetch_statements.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""scripts/fetch_statements.py   v1.2  (2025-06-08)
+"""scripts/fetch_statements.py   v1.3  (2025-06-08)
 ────────────────────────────────────────────────────────
 CHANGELOG:
+- 2025-06-08  v1.3 : jquantsapi.Client で statements を取得
 - 2025-06-08  v1.2 : fix .env path to repository root
 - 2025-06-08  v1.1 : .env から認証情報を読み込み、Refresh Token 対応
 - 2025-06-08  v1.0 : 初版。prices 内の銘柄の statements を CSV 保存
@@ -16,56 +17,35 @@ from pathlib import Path
 import logging
 
 import pandas as pd
-import requests
 from dotenv import load_dotenv
+from jquantsapi import Client
 
 # ──────────────────────────────────────────────────────────────
 ROOT = Path(__file__).resolve().parents[2]
 TEX_ROOT = ROOT / "tex-src"
 PRICES_DIR = TEX_ROOT / "data" / "prices"
 EARN_DIR = TEX_ROOT / "data" / "earn"
-API_BASE = "https://api.jquants.com/v1"
 
 load_dotenv(ROOT / ".env")
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def get_token() -> str:
+def get_client() -> Client:
     refresh = os.getenv("JQUANTS_REFRESH_TOKEN")
-    if refresh:
-        res = requests.post(
-            f"{API_BASE}/token/auth_refresh?refreshtoken={refresh}",
-            timeout=10,
-        )
-        res.raise_for_status()
-        return res.json().get("idToken")
-
     mail = os.getenv("JQUANTS_EMAIL")
     pwd = os.getenv("JQUANTS_PASSWORD")
-    if not (mail and pwd):
-        raise SystemExit("JQUANTS_EMAIL/PASSWORD not set")
 
-    res = requests.post(
-        f"{API_BASE}/token/auth_user",
-        data={"mailaddress": mail, "password": pwd},
-        timeout=10,
-    )
-    res.raise_for_status()
-    return res.json().get("accessToken")
+    if refresh:
+        return Client(refresh_token=refresh)
+    if mail and pwd:
+        return Client(mail_address=mail, password=pwd)
+
+    raise SystemExit("JQUANTS_EMAIL/PASSWORD not set")
 
 
-def fetch_statements(token: str, code: str, date: str) -> pd.DataFrame:
-    headers = {"Authorization": f"Bearer {token}"}
-    params = {"code": code, "date": date}
-    res = requests.get(f"{API_BASE}/fins/statements", headers=headers, params=params)
-    res.raise_for_status()
-    data = res.json()
-    if isinstance(data, dict) and "statements" in data:
-        records = data["statements"]
-    else:
-        records = data
-    return pd.DataFrame(records)
+def fetch_statements(cli: Client, code: str, date: str) -> pd.DataFrame:
+    return cli.get_fins_statements(code=code, date_yyyymmdd=date)
 
 
 def list_codes() -> list[str]:
@@ -81,11 +61,11 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    token = get_token()
+    client = get_client()
 
     EARN_DIR.mkdir(parents=True, exist_ok=True)
     for code in list_codes():
-        df = fetch_statements(token, code, args.date)
+        df = fetch_statements(client, code, args.date)
         out = EARN_DIR / f"{code}.csv"
         df.to_csv(out, index=False)
         logger.info("saved: %s", out)


### PR DESCRIPTION
## Summary
- implement `fetch_statements.py` to obtain earnings statement data from J-Quants API

## Testing
- `pip install -r requirements.txt` *(fails: Module build takes too long)*
- `pytest -q` *(fails: missing numpy due to install issue)*


------
https://chatgpt.com/codex/tasks/task_e_6844e7c9fb4c832884d986f75cacb2f2