### PR TITLE
Implement event diff and batch scripts with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,31 @@ python tex-src/scripts/csv_to_open_price_batch.py
 ```bash
 pdflatex tex-src/backtest_open_price.tex
 ```
+### `csv_to_event_diff.py`
+
+イベント係数 $\beta$ を用いた差分テーブルを生成します。出力先は `tex-src/data/analysis/event/` です。
+
+```bash
+python tex-src/scripts/csv_to_event_diff.py 8801.csv
+```
+
+### `csv_to_event_batch.py`
+
+`data/prices` 内の全 CSV を対象に `csv_to_event_diff.py` を実行し、`summary.tex` を同ディレクトリに保存します。
+
+```bash
+python tex-src/scripts/csv_to_event_batch.py
+```
+
+### `backtest_event.tex`
+
+生成した diff テーブルをまとめたバックテスト用 LaTeX です。
+
+```bash
+pdflatex tex-src/backtest_event.tex
+```
+
+
 
 ## Testing
 

--- a/tests/test_event_batch.py
+++ b/tests/test_event_batch.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+sys.path.insert(0, 'tex-src/scripts')
+
+spec = importlib.util.spec_from_file_location('batch', 'tex-src/scripts/csv_to_event_batch.py')
+batch = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(batch)
+
+
+def test_compute_metrics():
+    csv = Path('tex-src/data/prices/1321.csv')
+    raw = batch.read_prices(csv)
+    df = batch.calc_event_beta(raw)
+    mae, rmae, hit = batch.compute_metrics(df)
+    assert mae == df['MAE_5d'].iloc[-1]
+    assert rmae == df['RelMAE'].iloc[-1]
+    assert 0 <= hit <= 100
+
+
+def test_make_summary_contains_median():
+    rows = [('1321', 100.0, 1.0, 2.0, 50.0)]
+    tex = batch.make_summary(rows.copy())
+    assert 'Median' in tex
+
+
+def test_compute_metrics_custom():
+    csv = Path('tex-src/data/prices/1321.csv')
+    raw = batch.read_prices(csv)
+    df = batch.calc_event_beta(
+        raw,
+        eta=0.02, l_init=0.95, l_min=0.91, l_max=0.99
+    )
+    mae, rmae, hit = batch.compute_metrics(df)
+    assert mae == df['MAE_5d'].iloc[-1]
+    assert rmae == df['RelMAE'].iloc[-1]
+    assert 0 <= hit <= 100

--- a/tests/test_event_diff.py
+++ b/tests/test_event_diff.py
@@ -1,0 +1,40 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+sys.path.insert(0, 'tex-src/scripts')
+
+spec = importlib.util.spec_from_file_location('diff', 'tex-src/scripts/csv_to_event_diff.py')
+diff = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(diff)
+
+
+def test_calc_event_beta():
+    csv = Path('tex-src/data/prices/1321.csv')
+    df = diff.calc_event_beta(diff.read_prices(csv))
+    required = {
+        'MAE_5d', 'HitRate_20d', 'RelMAE',
+        'Beta_weekday', 'Beta_event', 'C_pred_evt'
+    }
+    assert required.issubset(df.columns)
+    assert 0 <= df['HitRate_20d'].iloc[-1] <= 100
+
+
+def test_process_one(tmp_path):
+    csv = Path('tex-src/data/prices/1321.csv')
+    out = diff.process_one(csv, out_dir=tmp_path)
+    assert out.exists()
+    text = out.read_text()
+    assert text.strip() != ''
+    assert text.count('\\begin{threeparttable}') == 1
+
+
+def test_make_table_newline():
+    csv = Path('tex-src/data/prices/1321.csv')
+    df = diff.calc_event_beta(diff.read_prices(csv))
+    tex = diff.make_table(df, title='code:1321')
+    lines = tex.splitlines()
+    assert lines[0].startswith('\\noindent')
+    assert lines[0].endswith('\\')
+    assert lines[1] == '\\begingroup'
+    assert tex.endswith('\\endgroup\n')

--- a/tex-src/backtest_event.tex
+++ b/tex-src/backtest_event.tex
@@ -1,0 +1,42 @@
+%-------------------------------------------------------------------------------
+% backtest_event.tex   v1.0  (2025-06-10)
+%-------------------------------------------------------------------------------
+% CHANGELOG
+% - 2025-06-10  v1.0 : 初版
+%-------------------------------------------------------------------------------
+
+\documentclass[dvipdfmx,oneside]{article}
+
+\usepackage{amsmath,amssymb,tabularx,booktabs,threeparttable}
+\usepackage{graphicx}
+\usepackage{geometry}
+\geometry{margin=15mm}
+\renewcommand{\arraystretch}{1.2}
+
+\begin{document}
+
+%=== event : summary (all codes) ==============================================
+\input{data/analysis/event/summary}
+\clearpage
+\input{data/analysis/event/1321_diff.tex}
+\clearpage
+\input{data/analysis/event/4755_diff.tex}
+\clearpage
+\input{data/analysis/event/6723_diff.tex}
+\clearpage
+\input{data/analysis/event/7203_diff.tex}
+\clearpage
+\input{data/analysis/event/8035_diff.tex}
+\clearpage
+\input{data/analysis/event/8604_diff.tex}
+\clearpage
+\input{data/analysis/event/8750_diff.tex}
+\clearpage
+\input{data/analysis/event/8801_diff.tex}
+\clearpage
+\input{data/analysis/event/9432_diff.tex}
+\clearpage
+\input{data/analysis/event/9984_diff.tex}
+\clearpage
+
+\end{document}

--- a/tex-src/scripts/csv_to_event_batch.py
+++ b/tex-src/scripts/csv_to_event_batch.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""scripts/csv_to_event_batch.py   v1.0  (2025-06-10)
+────────────────────────────────────────────────────────
+- CHANGELOG — scripts/csv_to_event_batch.py  （newest → oldest）
+- 2025-06-10  v1.0 : 初版
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+from csv_to_event_diff import (
+    process_one,
+    read_prices,
+    calc_event_beta,
+    ETA,
+    L_INIT,
+    L_MIN,
+    L_MAX,
+)
+
+PRICES_DIR = Path(__file__).resolve().parent.parent.parent / "tex-src" / "data/prices"
+OUT_DIR    = Path(__file__).resolve().parent.parent.parent / "tex-src" / "data/analysis/event"
+
+SUMMARY_TEX = OUT_DIR / "summary.tex"
+
+# ── モデル定数 ────────────────────────────────────────────────────────────
+def compute_metrics(df: pd.DataFrame) -> tuple[float, float, float]:
+    """MAE_5d, RelMAE, HitRate_20d (各最終行, %) を返す"""
+    mae = df["MAE_5d"].iloc[-1]
+    rmae = df["RelMAE"].iloc[-1]
+    hit = df["HitRate_20d"].iloc[-1]
+    return mae, rmae, hit
+
+# ── LaTeX summary 生成 ───────────────────────────────────────────────
+def make_summary(rows: list[tuple[str, float, float, float, float]]) -> str:
+    avg = lambda i: sum(r[i] for r in rows) / len(rows)
+    med = lambda i: float(np.median([r[i] for r in rows]))
+    rows.append(("Average", avg(1), avg(2), avg(3), avg(4)))
+    rows.append(("Median", med(1), med(2), med(3), med(4)))
+
+    def f(x: float) -> str:
+        return f"{x:,.2f}"
+
+    lines = [
+        r"\begingroup",
+        r"\footnotesize",
+        r"\begin{tabular}{lrrrr}",
+        r"\hline",
+        r"Code & Close & MAE\_5d & RelMAE[\%] & HitRate[\%] \\",
+        r"\hline",
+    ]
+    for code, close, mae, rmae, hit in rows:
+        lines.append(f"{code} & {f(close)} & {f(mae)} & {f(rmae)} & {f(hit)} \\")
+    lines += [r"\hline", r"\end{tabular}", r"\endgroup"]
+    return "\n".join(lines)
+
+# ── main ───────────────────────────────────────────────────────────────
+def main() -> None:
+    p = argparse.ArgumentParser(description="event batch processor")
+    p.add_argument("--eta", type=float, default=ETA, help="学習率 η")
+    p.add_argument("--init-lambda", type=float, default=L_INIT, help="初期 λ_shift")
+    p.add_argument("--min-lambda", type=float, default=L_MIN, help="最小 λ_shift")
+    p.add_argument("--max-lambda", type=float, default=L_MAX, help="最大 λ_shift")
+    args = p.parse_args()
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    rows: list[tuple[str, float, float, float, float]] = []
+    for csv_path in sorted(PRICES_DIR.glob("*.csv")):
+        out = process_one(
+            csv_path,
+            out_dir=OUT_DIR,
+            eta=args.eta,
+            l_init=args.init_lambda,
+            l_min=args.min_lambda,
+            l_max=args.max_lambda,
+        )
+        print(f"✅ {csv_path.stem} → {out.relative_to(OUT_DIR.parent.parent)}")
+
+        raw = read_prices(csv_path)
+        df = calc_event_beta(
+            raw,
+            eta=args.eta,
+            l_init=args.init_lambda,
+            l_min=args.min_lambda,
+            l_max=args.max_lambda,
+        )
+        mae, rmae, hit = compute_metrics(df)
+        close = df["Close"].iloc[-1]
+        rows.append((csv_path.stem, close, mae, rmae, hit))
+
+    SUMMARY_TEX.write_text(make_summary(rows), encoding="utf-8")
+    print(f"✅ summary.tex 生成: {SUMMARY_TEX.relative_to(OUT_DIR.parent)}")
+
+if __name__ == "__main__":
+    main()

--- a/tex-src/scripts/csv_to_event_diff.py
+++ b/tex-src/scripts/csv_to_event_diff.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""scripts/csv_to_event_diff.py   v1.0  (2025-06-10)
+────────────────────────────────────────────────────────
+- CHANGELOG — scripts/csv_to_event_diff.py  （newest → oldest）
+- 2025-06-10  v1.0 : 初版
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+# center_shift のロジックを流用
+from csv_to_center_shift_diff import (
+    read_prices,
+    calc_center_shift,
+    ETA,
+    L_INIT,
+    L_MIN,
+    L_MAX,
+)
+
+OUT_DIR = Path(__file__).resolve().parent.parent.parent / "tex-src" / "data/analysis/event"
+PRICES_DIR = Path(__file__).resolve().parent.parent.parent / "tex-src" / "data/prices"
+
+# ──────────────────────────────────────────────────────────────
+def resolve_csv(raw: Path) -> Path:
+    if raw.exists():
+        return raw.resolve()
+    alt = PRICES_DIR / raw.name
+    if alt.exists():
+        return alt.resolve()
+    raise FileNotFoundError(raw)
+
+# ──────────────────────────────────────────────────────────────
+def calc_event_beta(
+    df: pd.DataFrame,
+    *,
+    eta: float = ETA,
+    l_init: float = L_INIT,
+    l_min: float = L_MIN,
+    l_max: float = L_MAX,
+) -> pd.DataFrame:
+    base = calc_center_shift(df, phase=2, eta=eta, l_init=l_init, l_min=l_min, l_max=l_max)
+
+    dow = df["Date"].dt.dayofweek
+    wk_map = {0: 1.05, 1: 1.02, 2: 1.00, 3: 0.98, 4: 0.95}
+    beta_weekday = dow.map(wk_map).fillna(1.0)
+    beta_earn = np.ones(len(df))
+    beta_market = np.ones(len(df))
+    beta_event = beta_weekday * beta_earn * beta_market
+
+    out = base.copy()
+    out["Beta_weekday"] = beta_weekday.values
+    out["Beta_earn"] = beta_earn
+    out["Beta_market"] = beta_market
+    out["Beta_event"] = beta_event
+
+    out["C_pred_evt"] = out["C_pred"] * out["Beta_event"]
+    out["C_diff"] = out["C_pred_evt"] - out["C_real"]
+    out["C_diff_sign"] = np.sign(out["C_diff"])
+    out["Norm_err"] = np.abs(out["C_diff"]) / (out["B_{t-1}"] * out[r"$\sigma_t^{\mathrm{shift}}$"])
+    out["MAE_5d"] = out["C_diff"].abs().rolling(5, min_periods=1).mean()
+    out["RelMAE"] = out["MAE_5d"] / out["Close"] * 100
+    hit = (np.sign(out[r"$\alpha_t$"]) == np.sign(out["C_real"] - out["B_{t-1}"])).astype(int)
+    out["HitRate_20d"] = hit.rolling(20, min_periods=1).mean() * 100
+    return out
+
+# ──────────────────────────────────────────────────────────────
+NUM_ROWS = 30
+
+def make_table(df: pd.DataFrame, title: str = "") -> str:
+    dfn = df.tail(NUM_ROWS).iloc[::-1].reset_index(drop=True)
+
+    avg = {"Date": "Average"}
+    med = {"Date": "Median"}
+    for c in [
+        "Beta_weekday","Beta_earn","Beta_market","Beta_event",
+        "B_{t-1}","C_pred_evt","C_real","C_diff","C_diff_sign","Norm_err",
+        "MAE_5d","RelMAE","HitRate_20d",
+    ]:
+        vals = dfn[c].astype(float)
+        avg[c] = vals.mean()
+        med[c] = np.median(vals)
+    dfn = pd.concat([dfn, pd.DataFrame([avg, med])], ignore_index=True)
+
+    cols_src = [
+        "Date","Beta_weekday","Beta_earn","Beta_market","Beta_event",
+        "B_{t-1}","C_pred_evt","C_real","C_diff","C_diff_sign","Norm_err",
+        r"$\alpha_t$",r"$\lambda_{\text{shift}}$",r"$\Delta\alpha_t$",
+        "MAE_5d","RelMAE","HitRate_20d",
+    ]
+    header = {
+        "Beta_weekday": r"$\beta_{wd}$",
+        "Beta_earn": r"$\beta_{earn}$",
+        "Beta_market": r"$\beta_{mkt}$",
+        "Beta_event": r"$\beta_{evt}$",
+        "B_{t-1}": r"$B$",
+        "C_pred_evt": r"$C_p$",
+        "C_real": r"$C_r$",
+        "C_diff": r"$C_\Delta$",
+        "C_diff_sign": r"$\mathrm{sgn}\,C_\Delta$",
+        "Norm_err": r"$|C_\Delta|/\sigma$",
+        r"$\alpha_t$": r"$\alpha_t$",
+        r"$\lambda_{\text{shift}}$": r"$\lambda$",
+        r"$\Delta\alpha_t$": r"$\Delta\alpha$",
+        "MAE_5d": r"$\mathrm{MAE}_5$",
+        "RelMAE": r"$\mathrm{RMAE}$",
+        "HitRate_20d": r"$\mathrm{HR}_{20}[\%]$",
+    }
+    cols = [header.get(c, c) for c in cols_src]
+
+    def fmt(v, col):
+        if col == "Date":
+            return v
+        if pd.isna(v):
+            return "--"
+        if col in {r"$\beta_{wd}$", r"$\beta_{earn}$", r"$\beta_{mkt}$", r"$\beta_{evt}$",
+                    r"$\alpha_t$", r"$\lambda$", r"$\Delta\alpha$"}:
+            return f"{v:.2f}"
+        if col in {r"$\mathrm{RMAE}$", r"$\mathrm{HR}_{20}[\%]$"}:
+            return f"{v:.2f}"
+        return f"{v:.1f}"
+
+    disp = pd.DataFrame({
+        cols[i]: [fmt(v, cols[i]) for v in dfn[cols_src[i]]]
+        for i in range(len(cols))
+    })
+
+    with pd.option_context("mode.chained_assignment", None):
+        fmt_str = "l" + "r" * (len(cols) - 1)
+        latex_body = disp.to_latex(index=False, escape=False, column_format=fmt_str)
+
+    footnote_lines = [
+        r"\begin{tablenotes}\footnotesize",
+        r"\item $\beta_{wd}=\beta_{weekday}$, $B=B_{t-1}$,",
+        r"$C_p=C_{\text{pred}}\beta_{evt}$, $C_r=C_{\text{real}}$,",
+        r"$C_\Delta=C_{\text{diff}}$, $|C_\Delta|/\sigma=|C_{\text{diff}}|/\sigma_t^{\text{shift}}$.",
+        r"\end{tablenotes}",
+    ]
+    footnote = "\n".join(footnote_lines)
+
+    parts = []
+    if title:
+        parts.append(rf"\noindent\textbf{{{title}}}\\")
+    parts += [
+        r"\begingroup",
+        r"\footnotesize",
+        r"\setlength{\tabcolsep}{3.5pt}%",
+        r"\begin{threeparttable}",
+    ]
+    parts += [
+        r"\resizebox{\textwidth}{!}{%",
+        latex_body.rstrip(),
+        r"}",
+        footnote,
+        r"\end{threeparttable}",
+        r"\endgroup",
+    ]
+    return "\n".join(parts) + "\n"
+
+# ──────────────────────────────────────────────────────────────
+def process_one(
+    csv: Path,
+    out_dir: Path = OUT_DIR,
+    *,
+    eta: float = ETA,
+    l_init: float = L_INIT,
+    l_min: float = L_MIN,
+    l_max: float = L_MAX,
+) -> Path:
+    code = csv.stem
+    df = calc_event_beta(
+        read_prices(csv),
+        eta=eta,
+        l_init=l_init,
+        l_min=l_min,
+        l_max=l_max,
+    )
+    tex = make_table(df, title=f"code:{code}")
+    out = out_dir / f"{code}_diff.tex"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(tex, encoding="utf-8")
+    return out
+
+# ──────────────────────────────────────────────────────────────
+def main() -> None:
+    parser = argparse.ArgumentParser(description="event diff table")
+    parser.add_argument(
+        "csv", nargs="?", type=Path,
+        help="個別 CSV（省略時は data/prices/*.csv 一括処理）",
+    )
+    parser.add_argument("--eta", type=float, default=ETA, help="学習率 η")
+    parser.add_argument("--init-lambda", type=float, default=L_INIT, help="初期 λ_shift")
+    parser.add_argument("--min-lambda", type=float, default=L_MIN, help="最小 λ_shift")
+    parser.add_argument("--max-lambda", type=float, default=L_MAX, help="最大 λ_shift")
+    args = parser.parse_args()
+
+    kwargs = dict(eta=args.eta, l_init=args.init_lambda, l_min=args.min_lambda, l_max=args.max_lambda)
+
+    if args.csv is None:
+        for p in sorted(PRICES_DIR.glob("*.csv")):
+            out = process_one(p, **kwargs)
+            print(f"✅ {p.stem} → {out.relative_to(OUT_DIR.parent.parent)}")
+    else:
+        out = process_one(resolve_csv(args.csv), **kwargs)
+        print(f"✅ {args.csv.stem} → {out.relative_to(OUT_DIR.parent.parent)}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `csv_to_event_diff.py` and `csv_to_event_batch.py`
- create empty analysis/event directory with `.gitkeep`
- add `backtest_event.tex`
- document new scripts in README
- add tests for event diff and batch

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459d039e8c832880fba370a05947fa