### PR TITLE
Implement percentage ratio and outlier flag

### DIFF
--- a/tests/test_range_diff.py
+++ b/tests/test_range_diff.py
@@ -12,10 +12,14 @@ spec.loader.exec_module(diff)
 def test_calc_range():
     csv = Path('tex-src/data/prices/1321.csv')
     df = diff.calc_range(diff.read_prices(csv))
-    required = {'MAE_5d', 'HitRate_20d', 'RelMAE', 'B_final', 'M_ratio'}
+    required = {'MAE_5d', 'HitRate_20d', 'RelMAE', 'B_final', 'M_ratio', 'Outlier'}
     assert required.issubset(df.columns)
     assert df['M_ratio'].notna().any()
     assert 0 <= df['HitRate_20d'].iloc[-1] <= 100
+    assert set(df['Outlier'].unique()) <= {0, 1}
+    mask = df['M_ratio'].abs() >= 0.10
+    if mask.any():
+        assert (df.loc[mask, 'Outlier'] == 1).all()
 
 
 def test_process_one(tmp_path):
@@ -26,6 +30,7 @@ def test_process_one(tmp_path):
     assert text.strip() != ''
     assert text.count('\\begin{threeparttable}') == 3
     assert text.count('\\clearpage') == 2
+    assert 'm_\\Delta/m' in text and '\\mathrm{Out}' in text
 
 
 def test_custom_params():


### PR DESCRIPTION
## Summary
- show m_Δ/m_r in percentage for range diff tables
- flag rows as outliers when diff ratio exceeds 10%
- add Outlier column to LaTeX output with footnotes
- update tests for new Outlier behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e4854a788328aebb65f253c60816