### PR TITLE
Update fundamentals script and tests

### DIFF
--- a/tests/test_fundamentals_diff.py
+++ b/tests/test_fundamentals_diff.py
@@ -12,9 +12,12 @@ spec.loader.exec_module(fund)
 def test_make_table_and_process(tmp_path):
     events = Path('tests/fixtures/events.csv')
     out = tmp_path / 'fund.tex'
-    fund.process_all(events_csv=events, out_file=out, prices_dir=Path('tests/fixtures/prices'))
+    csv_out = tmp_path / 'fund.csv'
+    fund.process_all(events_csv=events, out_file=out, prices_dir=Path('tests/fixtures/prices'), csv_file=csv_out)
     assert out.exists()
     text = out.read_text()
-    assert '\\begin{tabular}' in text
+    assert '\\begin{longtable}' in text
     assert '1321' in text
-    assert any(suffix in text for suffix in ['_J_d', '_T_d', '_U_d-1'])
+    assert 'Total' in text
+    assert any(tag in text for tag in ['\\_J\\_d', '\\_T\\_d', '\\_U\\_d', '\\_U\\_d-1', '\\_U\\_d+1'])
+    assert csv_out.exists()


### PR DESCRIPTION
## Summary
- add a Total column and longtable output in `csv_to_fundamentals_diff.py`
- export results to `fundamentals.csv`
- update CLI options for CSV output
- revise unit test for fundamentals to check new table and CSV

## Testing
- `pip install -q pandas numpy`
- `pip install -q jinja2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849b2ed85d483288516140a42857625