### PR TITLE
Handle outlier rows in center shift diff

### DIFF
--- a/tests/test_center_shift_batch.py
+++ b/tests/test_center_shift_batch.py
@@ -14,8 +14,8 @@ def test_compute_metrics():
     raw = batch.read_prices(csv)
     df = batch.calc_center_shift(raw, phase=2)
     mae, rmae, hit = batch.compute_metrics(df)
-    assert mae == df['MAE_5d'].iloc[-1]
-    assert rmae == df['RelMAE'].iloc[-1]
+    assert mae == df['MAE_5d'].dropna().iloc[-1]
+    assert rmae == df['RelMAE'].dropna().iloc[-1]
     assert 0 <= hit <= 100
 
 
@@ -34,8 +34,8 @@ def test_compute_metrics_custom():
         eta=0.02, l_init=0.95, l_min=0.91, l_max=0.99
     )
     mae, rmae, hit = batch.compute_metrics(df)
-    assert mae == df['MAE_5d'].iloc[-1]
-    assert rmae == df['RelMAE'].iloc[-1]
+    assert mae == df['MAE_5d'].dropna().iloc[-1]
+    assert rmae == df['RelMAE'].dropna().iloc[-1]
     assert 0 <= hit <= 100
 
 

--- a/tests/test_center_shift_diff.py
+++ b/tests/test_center_shift_diff.py
@@ -16,12 +16,12 @@ def test_calc_center_shift_phase2():
         'MAE_5d', 'HitRate_20d', 'RelMAE', 'Outlier', 'C_ratio',
         r'$\lambda_{\text{shift}}$', r'$\Delta\alpha_t$'
     }.issubset(df.columns)
-    assert set(df['Outlier'].unique()) <= set(range(9))
+    assert set(df['Outlier'].unique()) <= set(range(10))
     assert df['C_ratio'].notna().any()
     assert 0 <= df['HitRate_20d'].iloc[-1] <= 100
-    mask = df['C_ratio'].abs() >= 0.02
+    mask = df['C_ratio'].abs() >= 0.01
     if mask.any():
-        assert set(df.loc[mask, 'Outlier'].unique()) <= set(range(1, 9))
+        assert set(df.loc[mask, 'Outlier'].unique()) <= set(range(2, 10))
 
 
 def test_event_outlier():

--- a/tests/test_event_batch.py
+++ b/tests/test_event_batch.py
@@ -14,8 +14,8 @@ def test_compute_metrics():
     raw = batch.read_prices(csv)
     df = batch.calc_event_beta(raw)
     mae, rmae, hit = batch.compute_metrics(df)
-    assert mae == df['MAE_5d'].iloc[-1]
-    assert rmae == df['RelMAE'].iloc[-1]
+    assert mae == df['MAE_5d'].dropna().iloc[-1]
+    assert rmae == df['RelMAE'].dropna().iloc[-1]
     assert 0 <= hit <= 100
 
 
@@ -33,6 +33,6 @@ def test_compute_metrics_custom():
         eta=0.02, l_init=0.95, l_min=0.91, l_max=0.99
     )
     mae, rmae, hit = batch.compute_metrics(df)
-    assert mae == df['MAE_5d'].iloc[-1]
-    assert rmae == df['RelMAE'].iloc[-1]
+    assert mae == df['MAE_5d'].dropna().iloc[-1]
+    assert rmae == df['RelMAE'].dropna().iloc[-1]
     assert 0 <= hit <= 100

--- a/tex-src/scripts/csv_to_center_shift_batch.py
+++ b/tex-src/scripts/csv_to_center_shift_batch.py
@@ -51,9 +51,9 @@ SUMMARY_TEX = OUT_DIR / "summary.tex"
 # ── モデル定数（batch 側でメトリクス計算に必要） ──────────────────────────
 def compute_metrics(df: pd.DataFrame) -> tuple[float, float, float]:
     """MAE_5d, RelMAE, HitRate_20d (各最終行, %) を返す"""
-    mae = df["MAE_5d"].iloc[-1]
-    rmae = df["RelMAE"].iloc[-1]
-    hit = df["HitRate_20d"].iloc[-1]
+    mae = df["MAE_5d"].dropna().iloc[-1]
+    rmae = df["RelMAE"].dropna().iloc[-1]
+    hit = df["HitRate_20d"].dropna().iloc[-1]
     return mae, rmae, hit
 
 # ── LaTeX summary 生成 ──────────────────────────────────────────────────

--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.35  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.36  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-13  v2.36: 外れ値閾値1%とし一般行を Outlier=9
 - 2025-06-13  v2.35: 外れ値行を NaN で無効化し再計算
 - 2025-06-13  v2.34: Outlier 区分0-8の優先処理を追加
 - 2025-06-13  v2.33: read_statement_events を追加
@@ -220,7 +221,7 @@ def calc_center_shift(
     out["C_diff_sign"] = np.sign(out["C_diff"])
     out["Norm_err"]    = np.abs(out["C_diff"]) / (out["B_{t-1}"] * out[r"$\sigma_t^{\mathrm{shift}}$"])
     z = (out["Norm_err"] - out["Norm_err"].mean()) / out["Norm_err"].std(ddof=0)
-    ratio_flag = np.abs(out["C_ratio"]) >= 0.02
+    ratio_flag = np.abs(out["C_ratio"]) >= 0.01
     out_flag = ((np.abs(z) > 3) | ratio_flag).astype(int)
     dates_norm = df["Date"].dt.normalize()
     categories = np.zeros(n, dtype=int)
@@ -243,7 +244,7 @@ def calc_center_shift(
         elif 8 in special_dates and d in special_dates[8]:
             cat = 8
         else:
-            cat = 1
+            cat = 9
         categories[i] = cat
     out["Outlier"] = categories
 

--- a/tex-src/scripts/csv_to_event_batch.py
+++ b/tex-src/scripts/csv_to_event_batch.py
@@ -31,9 +31,9 @@ SUMMARY_TEX = OUT_DIR / "summary.tex"
 # ── モデル定数 ────────────────────────────────────────────────────────────
 def compute_metrics(df: pd.DataFrame) -> tuple[float, float, float]:
     """MAE_5d, RelMAE, HitRate_20d (各最終行, %) を返す"""
-    mae = df["MAE_5d"].iloc[-1]
-    rmae = df["RelMAE"].iloc[-1]
-    hit = df["HitRate_20d"].iloc[-1]
+    mae = df["MAE_5d"].dropna().iloc[-1]
+    rmae = df["RelMAE"].dropna().iloc[-1]
+    hit = df["HitRate_20d"].dropna().iloc[-1]
     return mae, rmae, hit
 
 # ── LaTeX summary 生成 ─────────────────────────────────────────────────────

--- a/tex-src/scripts/csv_to_open_price_batch.py
+++ b/tex-src/scripts/csv_to_open_price_batch.py
@@ -35,9 +35,9 @@ SUMMARY_TEX = OUT_DIR / "summary.tex"
 # ── モデル定数（batch 側でメトリクス計算に必要） ──────────────────────────
 def compute_metrics(df: pd.DataFrame) -> tuple[float, float, float]:
     """MAE_5d, RelMAE, HitRate_20d (各最終行, %) を返す"""
-    mae = df["MAE_5d"].iloc[-1]
-    rmae = df["RelMAE"].iloc[-1]
-    hit = df["HitRate_20d"].iloc[-1]
+    mae = df["MAE_5d"].dropna().iloc[-1]
+    rmae = df["RelMAE"].dropna().iloc[-1]
+    hit = df["HitRate_20d"].dropna().iloc[-1]
     return mae, rmae, hit
 
 # ── LaTeX summary 生成 ──────────────────────────────────────────────────

--- a/tex-src/scripts/csv_to_range_batch.py
+++ b/tex-src/scripts/csv_to_range_batch.py
@@ -28,9 +28,9 @@ SUMMARY_TEX = OUT_DIR / "summary.tex"
 
 
 def compute_metrics(df: pd.DataFrame) -> tuple[float, float, float]:
-    mae = df["MAE_5d"].iloc[-1]
-    rmae = df["RelMAE"].iloc[-1]
-    hit = df["HitRate_20d"].iloc[-1]
+    mae = df["MAE_5d"].dropna().iloc[-1]
+    rmae = df["RelMAE"].dropna().iloc[-1]
+    hit = df["HitRate_20d"].dropna().iloc[-1]
     return mae, rmae, hit
 
 


### PR DESCRIPTION
## Summary
- ignore outlier rows in `csv_to_center_shift_diff.py`
- regenerate metrics after nulling outliers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bf613f744832886ae77d03a9b9af7