### PR TITLE
Allow values for outlier 9

### DIFF
--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.40  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.41  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-13  v2.41: Outlier=9 行でも値を表示
 - 2025-06-13  v2.40: Phase6 で B_ma10 を基準値に使用
 - 2025-06-13  v2.39: B_ma5/B_ma10 平滑化を Phase5 用に追加
 - 2025-06-13  v2.38: ratio_flag を単日±1%に戻し平均は参考値
@@ -261,7 +262,7 @@ def calc_center_shift(
         categories[i] = cat
     out["Outlier"] = categories
 
-    mask = out["Outlier"] != 0
+    mask = (out["Outlier"] != 0) & (out["Outlier"] != 9)
     cols = [
         "High",
         "Low",

--- a/tex-src/scripts/csv_to_center_shift_diff.py
+++ b/tex-src/scripts/csv_to_center_shift_diff.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-scripts/csv_to_center_shift_diff.py   v2.41  (2025-06-06)
+scripts/csv_to_center_shift_diff.py   v2.42  (2025-06-06)
 ────────────────────────────────────────────────────────
 - CHANGELOG — scripts/csv_to_center_shift_diff.py  （newest → oldest）
+- 2025-06-14  v2.42: 外れ値閾値を±2%に戻し Outlier=9 行を表示
 - 2025-06-13  v2.41: Outlier=9 行でも値を表示
 - 2025-06-13  v2.40: Phase6 で B_ma10 を基準値に使用
 - 2025-06-13  v2.39: B_ma5/B_ma10 平滑化を Phase5 用に追加
@@ -235,7 +236,7 @@ def calc_center_shift(
     out["C_diff_sign"] = np.sign(out["C_diff"])
     out["Norm_err"]    = np.abs(out["C_diff"]) / (base * out[r"$\sigma_t^{\mathrm{shift}}$"])
     z = (out["Norm_err"] - out["Norm_err"].mean()) / out["Norm_err"].std(ddof=0)
-    ratio_flag = np.abs(out["C_ratio"]) >= 0.01
+    ratio_flag = np.abs(out["C_ratio"]) >= 0.02
     out_flag = ((np.abs(z) > 3) | ratio_flag).astype(int)
     dates_norm = df["Date"].dt.normalize()
     categories = np.zeros(n, dtype=int)


### PR DESCRIPTION
## Summary
- keep numeric values for rows marked Outlier=9
- document change in script CHANGELOG

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684caa22cdc88328b8fe5e07a75dd00c