### PR TITLE
Add sign verification columns

### DIFF
--- a/tests/test_center_shift_batch.py
+++ b/tests/test_center_shift_batch.py
@@ -14,8 +14,13 @@ def test_compute_metrics():
     raw = batch.read_prices(csv)
     df = batch.calc_center_shift(raw, phase=2)
     mae, rmae, hit = batch.compute_metrics(df)
-    assert mae == df['MAE_10d'].dropna().iloc[-1]
-    assert rmae == df['RelMAE'].dropna().iloc[-1]
+    expect_mae = df['C_diff'].abs().rolling(10, min_periods=1).mean().dropna().iloc[-1]
+    expect_rmae = (
+        df['C_diff'].abs().rolling(5, min_periods=1).mean()
+        .div(df['Close']).mul(100).dropna().iloc[-1]
+    )
+    assert mae == expect_mae
+    assert rmae == expect_rmae
     assert 0 <= hit <= 100
 
 
@@ -34,8 +39,13 @@ def test_compute_metrics_custom():
         eta=0.02, l_init=0.95, l_min=0.91, l_max=0.99
     )
     mae, rmae, hit = batch.compute_metrics(df)
-    assert mae == df['MAE_10d'].dropna().iloc[-1]
-    assert rmae == df['RelMAE'].dropna().iloc[-1]
+    expect_mae = df['C_diff'].abs().rolling(10, min_periods=1).mean().dropna().iloc[-1]
+    expect_rmae = (
+        df['C_diff'].abs().rolling(5, min_periods=1).mean()
+        .div(df['Close']).mul(100).dropna().iloc[-1]
+    )
+    assert mae == expect_mae
+    assert rmae == expect_rmae
     assert 0 <= hit <= 100
 
 

--- a/tests/test_center_shift_diff.py
+++ b/tests/test_center_shift_diff.py
@@ -13,13 +13,13 @@ def test_calc_center_shift_phase2():
     csv = Path('tex-src/data/prices/1321.csv')
     df = diff.calc_center_shift(diff.read_prices(csv), phase=2)
     assert {
-        'MAE_5d', 'MAE_10d', 'HitRate_20d', 'RelMAE', 'Outlier', 'C_ratio', 'C_ratio_ma10',
+        'Outlier', 'C_ratio', 'S_t,p', 'S_r', 'S_verification',
         r'$\lambda_{\text{shift}}$', r'$\Delta\alpha_t$'
     }.issubset(df.columns)
     assert set(df['Outlier'].unique()) <= set(range(10))
     assert df['C_ratio'].notna().any()
-    assert df['C_ratio_ma10'].notna().any()
-    assert 0 <= df['HitRate_20d'].iloc[-1] <= 100
+    assert df['S_t,p'].isin([-1, 0, 1]).all()
+    assert df['S_verification'].isin([0, 1]).all()
     mask = df['C_ratio'].abs() >= 0.01
     if mask.any():
         assert set(df.loc[mask, 'Outlier'].unique()) <= set(range(2, 10))


### PR DESCRIPTION
## Summary
- update center shift diff metrics: drop MAE/RelMAE columns
- add S_t,p, S_r and S_verification columns
- adjust LaTeX outputs and footnotes accordingly
- compute metrics on demand in center shift batch
- update tests for new columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6d1ad0608328ac453eae58c524a5